### PR TITLE
Adding Sentinel-1 example and updating conf.py to run sphinx to build the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -236,3 +236,5 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+eodal.code-workspace

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,11 +18,11 @@ import sys
 import tempfile
 from inspect import getsourcefile
 
-DOCS_DIRECTORY = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
-REPO_DIRECTORY = os.path.dirname(DOCS_DIRECTORY)
+DOCS_SOURCE_DIR = os.path.dirname(os.path.abspath(getsourcefile(lambda: 0)))
+DOCS_DIR = os.path.dirname(DOCS_SOURCE_DIR)
+REPO_DIR = os.path.dirname(DOCS_DIR)
 
-sys.path.insert(0, DOCS_DIRECTORY)
-sys.path.insert(0, REPO_DIRECTORY)
+sys.path.insert(0, REPO_DIR)
 
 from eodal import __meta__ as meta  # noqa: E402 isort:skip
 
@@ -60,7 +60,7 @@ def run_apidoc(_):
         "--separate",  # Put each module file in its own page
         "--module-first",  # Put module documentation before submodule
         "-o",
-        "source/packages",  # Output path
+        os.path.join(DOCS_SOURCE_DIR, "packages"),  # Output path
         os.path.join("..", project_path),
     ] + ignore_paths
 
@@ -81,7 +81,7 @@ def retitle_modules(_):
     """
     Overwrite the title of the modules.rst file.
     """
-    pth = "source/packages/modules.rst"
+    pth = os.path.join(DOCS_SOURCE_DIR, "packages", "modules.rst")
     lines = open(pth).read().splitlines()
     # Overwrite the junk in the first two lines with a better title
     lines[0] = "API Reference"
@@ -97,9 +97,9 @@ def auto_convert_readme(_):
     Otherwise, and if it exists, converts README.md to to rST format, the
     output of which is docs/source/readme.rst.
     """
-    readme_path_md = os.path.join(REPO_DIRECTORY, "README.md")
+    readme_path_md = os.path.join(REPO_DIR, "README.md")
     readme_path_rst = os.path.splitext(readme_path_md)[0] + ".rst"
-    readme_path_output = os.path.join(DOCS_DIRECTORY, "source", "readme.rst")
+    readme_path_output = os.path.join(DOCS_SOURCE_DIR, "readme.rst")
     # Ensure output directory exists
     output_dir = os.path.dirname(readme_path_output)
     os.makedirs(output_dir, exist_ok=True)
@@ -124,7 +124,7 @@ def auto_convert_readme(_):
         # Download pandoc if necessary. If pandoc is already installed and on
         # the PATH, the installed version will be used. Otherwise, we will
         # download a copy of pandoc into docs/bin/ and add that to our PATH.
-        pandoc_dir = os.path.join(DOCS_DIRECTORY, "bin")
+        pandoc_dir = os.path.join(DOCS_DIR, "bin")
         os.environ["PATH"] += os.pathsep + pandoc_dir
         pypandoc.ensure_pandoc_installed(
             quiet=True,

--- a/eodal/core/band.py
+++ b/eodal/core/band.py
@@ -758,6 +758,7 @@ class Band(object):
                 in_dataset=vector_features,
                 fname_raster=_fpath_raster,
                 full_bounding_box_only=full_bounding_box_only,
+                raster_crs=epsg_code
             )
             # check for third dimension (has_z) and flatten it to 2d
             gdf_aoi.geometry = convert_3D_2D(gdf_aoi.geometry)

--- a/eodal/utils/reprojection.py
+++ b/eodal/utils/reprojection.py
@@ -133,6 +133,7 @@ def check_aoi_geoms(
     sat_crs = None
     if fname_raster is not None:
         sat_crs = rio.open(fname_raster).crs
+    # if the raster has no inherent CRS use the user-defined one
     if raster_crs is not None and sat_crs is None:
         sat_crs = raster_crs
 

--- a/scripts/sentinel1_mapper.py
+++ b/scripts/sentinel1_mapper.py
@@ -1,0 +1,57 @@
+
+from datetime import datetime
+from eodal.config import get_settings
+from eodal.core.sensors import Sentinel1
+from eodal.mapper.feature import Feature
+from eodal.mapper.filter import Filter
+from eodal.mapper.mapper import Mapper, MapperConfigs
+from shapely.geometry import Polygon
+
+Settings = get_settings()
+
+if __name__ == '__main__':
+
+    collection = 'sentinel1-grd'
+    time_start = datetime(2020,7,1)
+    time_end = datetime(2020,7,15)
+    geom = Polygon(
+        [[493504.953633058525156, 5258840.576098721474409],
+        [493511.206339373020455, 5258839.601945200935006],
+        [493510.605988947849255, 5258835.524093257263303],
+        [493504.296645800874103, 5258836.554883609525859],
+        [493504.953633058525156, 5258840.576098721474409]]
+    )
+    metadata_filters = [Filter('product_type','==', 'GRD')]
+
+    Settings.USE_STAC = True
+
+    feature = Feature(
+        name='Test Area',
+        geometry=geom,
+        epsg=32632,
+        attributes={'id': 1}
+    )
+    mapper_configs = MapperConfigs(
+        collection=collection,
+        time_start=time_start,
+        time_end=time_end,
+        feature=feature,
+        metadata_filters=metadata_filters
+    )
+    mapper = Mapper(mapper_configs)
+    mapper.query_scenes()
+
+    mapper.metadata
+
+    scene_kwargs = {
+	    'scene_constructor': Sentinel1.from_safe,
+	    'scene_constructor_kwargs': {'epsg_code': 4326}
+	}
+    mapper.load_scenes(scene_kwargs=scene_kwargs)
+
+    import rasterio as rio
+    import planetary_computer
+    fpath = mapper.metadata.real_path.iloc[0]['vh']['href']
+    ds = rio.open(planetary_computer.sign_url(fpath))
+
+    ds_l = rio.open('/mnt/ides/Lukas/Download/iw-vh.tiff')

--- a/scripts/sentinel1_mapper.py
+++ b/scripts/sentinel1_mapper.py
@@ -1,3 +1,30 @@
+"""
+Script to extract a collection of Sentinel-1 RTC scenes for a
+custom area of interest (AOI).
+
+The script should run as is on Microsoft Planetary Computer Hub
+(https://planetarycomputer.microsoft.com/compute).
+
+When using locally, make sure you have a valid MSPC subscription key
+(see also: https://planetarycomputer.microsoft.com/docs/concepts/sas/#when-an-account-is-needed)
+
+The key must be made available to EOdal using the PC_SDK_SUBSCRIPTION_KEY
+
+Copyright (C) 2022/23 Lukas Valentin Graf
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
 from datetime import datetime
 from eodal.config import get_settings
@@ -5,30 +32,26 @@ from eodal.core.sensors import Sentinel1
 from eodal.mapper.feature import Feature
 from eodal.mapper.filter import Filter
 from eodal.mapper.mapper import Mapper, MapperConfigs
-from shapely.geometry import Polygon
+from shapely.geometry import box
 
 Settings = get_settings()
+Settings.USE_STAC = True
 
 if __name__ == '__main__':
 
     collection = 'sentinel1-grd'
     time_start = datetime(2020,7,1)
     time_end = datetime(2020,7,15)
-    geom = Polygon(
-        [[493504.953633058525156, 5258840.576098721474409],
-        [493511.206339373020455, 5258839.601945200935006],
-        [493510.605988947849255, 5258835.524093257263303],
-        [493504.296645800874103, 5258836.554883609525859],
-        [493504.953633058525156, 5258840.576098721474409]]
-    )
-    metadata_filters = [Filter('product_type','==', 'GRD')]
 
-    Settings.USE_STAC = True
+    # 
+    bbox = [9.0924, 47.5992, 9.2190, 47.7295]
+    geom = box(*bbox)
+    metadata_filters = [Filter('product_type','==', 'RTC')]
 
     feature = Feature(
         name='Test Area',
         geometry=geom,
-        epsg=32632,
+        epsg=4326,
         attributes={'id': 1}
     )
     mapper_configs = MapperConfigs(
@@ -45,13 +68,7 @@ if __name__ == '__main__':
 
     scene_kwargs = {
 	    'scene_constructor': Sentinel1.from_safe,
-	    'scene_constructor_kwargs': {'epsg_code': 4326}
+	    'scene_constructor_kwargs': {}
 	}
     mapper.load_scenes(scene_kwargs=scene_kwargs)
-
-    import rasterio as rio
-    import planetary_computer
-    fpath = mapper.metadata.real_path.iloc[0]['vh']['href']
-    ds = rio.open(planetary_computer.sign_url(fpath))
-
-    ds_l = rio.open('/mnt/ides/Lukas/Download/iw-vh.tiff')
+    f = mapper.data.plot(band_selection=['VH'], figsize=(20,10))


### PR DESCRIPTION
This PR adds an example showing how the Mapper class can be used to retrieve ESA Sentinel-1 SAR data (radiometrically and terrain corrected). Moreover, the conf.py file has been updated from the [template](https://raw.githubusercontent.com/scottclowe/python-template-repo/master/docs/source/conf.py) provided by @scottclowe.