### PR TITLE
fix: error when clipping scene collection loaded from pickle file

### DIFF
--- a/eodal/core/scene.py
+++ b/eodal/core/scene.py
@@ -85,8 +85,10 @@ class SceneCollection(MutableMapping):
             if self.indexed_by_timestamps:
                 if str(key) in self.timestamps:
                     # most likely time stamps are passed as strings
+                    # ^^ not true for scene collection loaded from pickle file
                     # we infer the format using dateutil
-                    key = dateutil.parser.parse(key)
+                    if isinstance(key, str):
+                        key = dateutil.parser.parse(key)
                     return self.collection[key]
             else:
                 if key in self.timestamps:


### PR DESCRIPTION
In majority of case assumption the scene collection key is string is correct.
However, if it's already datetime, SceneCollection.clip_scenes throws an error:
TypeError: Parser must be a string or character stream, not datetime