### PR TITLE
Migration to pydantic v2

### DIFF
--- a/eodal/config/settings.py
+++ b/eodal/config/settings.py
@@ -45,17 +45,6 @@ class Settings(BaseSettings):
     or environmental variables
     """
 
-    # sat archive definitions
-    SUBDIR_PIXEL_CSVS: str = "tables_w_pixelvalues"
-    SUBDIR_RGB_PREVIEWS: str = "rgb_previews"
-    SUBDIR_SCL_FILES: str = "scene_classification"
-
-    RESAMPLED_METADATA_FILE: str = "metadata.csv"
-
-    # define date format
-    DATE_FMT_INPUT: str = "%Y-%m-%d"
-    DATE_FMT_FILES: str = "%Y%m%d"
-
     # define DHUS username and password
     DHUS_USER: str = ""
     DHUS_PASSWORD: str = ""
@@ -108,10 +97,6 @@ class Settings(BaseSettings):
     LOG_DIR: str = str(Path.home())  # ..versionadd:: 0.2.1
     LOG_FILE: str = join(LOG_DIR, f"{CURRENT_TIME}_{LOGGER_NAME}.log")
     LOGGING_LEVEL: int = logging.INFO
-
-    # processing checks
-    PROCESSING_CHECK_FILE_NO_BF: str = "successful_scenes_noblackfill.txt"
-    PROCESSING_CHECK_FILE_BF: str = "successful_scenes_blackfill.txt"
 
     # temporary working directory
     TEMP_WORKING_DIR: Path = Path(tempfile.gettempdir())

--- a/eodal/config/settings.py
+++ b/eodal/config/settings.py
@@ -32,7 +32,7 @@ from datetime import datetime
 from functools import lru_cache
 from os.path import join
 from pathlib import Path
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 from typing import Any
 
 from .stac_providers import STAC_Providers

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ geopandas
 sqlalchemy
 geoalchemy2
 numpy
-pydantic
+pydantic-settings
 pyproj
 rasterio
 matplotlib


### PR DESCRIPTION
This PR fixes #73 caused by the release of `pydantic` version 2. The newly required package `pydantic-settings` has been added to the EOdal requirements and the imports in the `eodal.config.settings.py` module have been updated.

In addition, some entries in the settings which were old legacy code from the very early days of EOdal but are not used any longer since also quiet a while have been removed.