### PR TITLE
Fix stac retries

### DIFF
--- a/eodal/metadata/stac/client.py
+++ b/eodal/metadata/stac/client.py
@@ -62,6 +62,7 @@ def query_stac(
         backoff_factor=1,
         status_forcelist=[502, 503, 504])
     stac_api_io.session.mount("http://", HTTPAdapter(max_retries=retries))
+    stac_api_io.session.mount("https://", HTTPAdapter(max_retries=retries))
 
     # handle certificate bundle
     stac_api_io.session.verify = Settings.STAC_API_IO_CA_BUNDLE

--- a/eodal/metadata/stac/client.py
+++ b/eodal/metadata/stac/client.py
@@ -55,8 +55,8 @@ def query_stac(
 
     # ..versionadd:: 0.2.1
     # add retries in case of HTTP 502, 503 and 504 errors
-    # TODO this should be changed once
-    # https://github.com/stac-utils/pystac-client/issues/520 is solved
+    # TODO pass `Retry` object to `StacApiIO` with python >= 3.8
+    # and `pystac-client` >= 0.7.0.
     retries = Retry(
         total=Settings.NUMBER_HTTPS_RETRIES,
         backoff_factor=1,


### PR DESCRIPTION
The current STAC retry code misses to mount the `HTTPAdapter` for the `https` protocol. 