### PR TITLE
Fix of nodata, fill value, mask and data type propagation in EOdal

### DIFF
--- a/eodal/__meta__.py
+++ b/eodal/__meta__.py
@@ -15,4 +15,4 @@ author_email = ""
 description = "Earth Observation Data Analysis Library"  # One-liner
 url = "https://github.com/EOA-team/eodal"  # your project home-page
 license = "GNU General Public License version 3"  # See https://choosealicense.com
-version = "0.2.2"
+version = "0.2.3"

--- a/eodal/core/algorithms.py
+++ b/eodal/core/algorithms.py
@@ -39,10 +39,10 @@ Settings = get_settings()
 
 def _get_crs_and_attribs(
     in_file: Path, **kwargs
-) -> Tuple[GeoInfo, List[Dict[str, Any]]]:
+) -> Tuple[GeoInfo, List[Dict[str, Any]], str]:
     """
     Returns the ``GeoInfo``, attributes and data type from
-    a multi-band raster dataset
+    a multi-band raster dataset.
 
     :param in_file:
         raster datasets from which to extract the ``GeoInfo`` and
@@ -133,10 +133,11 @@ def merge_datasets(
     # use rasterio merge to get a new raster dataset
     dst_kwds = {"QUALITY": "100", "REVERSIBLE": "YES"}
     try:
-        res = merge(datasets=datasets, dst_path=out_file, dst_kwds=dst_kwds, **kwargs)
+        res = merge(
+            datasets=datasets, dst_path=out_file, dst_kwds=dst_kwds,
+            dtype=dtype, **kwargs)
         if res is not None:
             out_ds, out_transform = res[0], res[1]
-            out_ds = out_ds.astype(dtype)
     except Exception as e:
         raise Exception(f"Could not merge datasets: {e}")
 

--- a/eodal/core/band.py
+++ b/eodal/core/band.py
@@ -2207,26 +2207,24 @@ class Band(object):
         scale, offset = self.scale, self.offset
         if self.is_masked_array:
             if pixel_values_to_ignore is None:
-                scaled_array = scale * (self.values.data - offset)
+                scaled_array = scale * self.values.data - offset
             else:
                 scaled_array = self.values.data.copy().astype(float)
-                scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)] = scale * (
-                    scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)]
+                scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)] = scale * \
+                    scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)] \
                     - offset
-                )
             # reuse fill value
             fill_value = self.values.fill_value
             scaled_array = np.ma.MaskedArray(
                 data=scaled_array, mask=self.values.mask, fill_value=fill_value)
         elif self.is_ndarray:
             if pixel_values_to_ignore is None:
-                scaled_array = scale * (self.values - offset)
+                scaled_array = scale * self.values - offset
             else:
                 scaled_array = self.values.copy().astype(float)
-                scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)] = scale * (
-                    scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)]
+                scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)] = scale * \
+                    scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)] \
                     - offset
-                )
         elif self.is_zarr:
             raise NotImplementedError()
 

--- a/eodal/core/band.py
+++ b/eodal/core/band.py
@@ -2211,7 +2211,10 @@ class Band(object):
                     scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)]
                     + offset
                 )
-            scaled_array = np.ma.MaskedArray(data=scaled_array, mask=self.values.mask)
+            # reuse fill value
+            fill_value = self.values.fill_value
+            scaled_array = np.ma.MaskedArray(
+                data=scaled_array, mask=self.values.mask, fill_value=fill_value)
         elif self.is_ndarray:
             if pixel_values_to_ignore is None:
                 scaled_array = scale * (self.values + offset)

--- a/eodal/core/band.py
+++ b/eodal/core/band.py
@@ -1895,8 +1895,10 @@ class Band(object):
             out_mask = cv2.resize(in_mask, dim_resampled, cv2.INTER_NEAREST_EXACT)
             # convert mask back to boolean array
             out_mask = out_mask.astype(bool)
+            # re-use fill value of the original array
+            fill_value = self.values.fill_value
             # save as masked array
-            res = np.ma.masked_array(data=res, mask=out_mask)
+            res = np.ma.masked_array(data=res, mask=out_mask, fill_value=fill_value)
 
         # update the geo_info with new pixel resolution. The upper left x and y
         # coordinate must be changed if the pixel coordinates refer to the center
@@ -1967,6 +1969,7 @@ class Band(object):
         if self.is_masked_array:
             band_data = deepcopy(self.values.data).astype(float)
             band_mask = deepcopy(self.values.mask).astype(float)
+            fill_value = self.values.fill_value
         elif self.is_ndarray:
             band_data = deepcopy(self.values).astype(float)
         elif self.is_zarr:
@@ -2009,7 +2012,8 @@ class Band(object):
             # due to the raster alignment
             nodata = reprojection_options.get("src_nodata", 0)
             out_mask[out_data == nodata] = True
-            out_data = np.ma.MaskedArray(data=out_data, mask=out_mask)
+            out_data = np.ma.MaskedArray(
+                data=out_data, mask=out_mask, fill_value=fill_value)
 
         new_geo_info = GeoInfo.from_affine(affine=out_transform, epsg=target_crs)
         if inplace:

--- a/eodal/core/band.py
+++ b/eodal/core/band.py
@@ -2207,12 +2207,12 @@ class Band(object):
         scale, offset = self.scale, self.offset
         if self.is_masked_array:
             if pixel_values_to_ignore is None:
-                scaled_array = scale * (self.values.data + offset)
+                scaled_array = scale * (self.values.data - offset)
             else:
                 scaled_array = self.values.data.copy().astype(float)
                 scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)] = scale * (
                     scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)]
-                    + offset
+                    - offset
                 )
             # reuse fill value
             fill_value = self.values.fill_value
@@ -2220,12 +2220,12 @@ class Band(object):
                 data=scaled_array, mask=self.values.mask, fill_value=fill_value)
         elif self.is_ndarray:
             if pixel_values_to_ignore is None:
-                scaled_array = scale * (self.values + offset)
+                scaled_array = scale * (self.values - offset)
             else:
                 scaled_array = self.values.copy().astype(float)
                 scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)] = scale * (
                     scaled_array[~np.isin(scaled_array, pixel_values_to_ignore)]
-                    + offset
+                    - offset
                 )
         elif self.is_zarr:
             raise NotImplementedError()

--- a/eodal/core/band.py
+++ b/eodal/core/band.py
@@ -1707,7 +1707,10 @@ class Band(object):
                 mask=orig_mask,
                 fill_value=fill_value)
         elif self.is_ndarray:
-            masked_array = np.ma.MaskedArray(data=self.values, mask=mask)
+            # determine fill value from nodata value
+            fill_value = self.nodata
+            masked_array = np.ma.MaskedArray(
+                data=self.values, mask=mask, fill_value=fill_value)
         elif self.is_zarr:
             raise NotImplementedError()
 

--- a/eodal/core/band.py
+++ b/eodal/core/band.py
@@ -861,6 +861,13 @@ class Band(object):
             nodata, nodata_vals = None, attrs.get("nodatavals", None)
             if nodata_vals is not None:
                 nodata = nodata_vals[band_idx - 1]
+        # make sure the nodata type matches the datatype of the
+        # band values
+        if band_data.dtype.kind not in 'fc' and np.isnan(nodata):
+            raise TypeError(
+                f"The datatype of the band data is {band_data.dtype} " +
+                f"while the nodata value ({nodata}) is float.\n" +
+                "Please provide an appropriate nodata value")
 
         if masking:
             # make sure to set the EPSG code

--- a/eodal/core/band.py
+++ b/eodal/core/band.py
@@ -2379,3 +2379,5 @@ class Band(object):
                 dst.write(self.values, 1)
             elif self.is_ndarray:
                 dst.write(self.values, 1)
+
+            # TODO: Write scale and offset to the file's metadata

--- a/eodal/core/band.py
+++ b/eodal/core/band.py
@@ -1691,6 +1691,7 @@ class Band(object):
             )
 
         # check if array is already masked
+        fill_value = None
         if self.is_masked_array:
             orig_mask = self.values.mask
             # update the existing mask

--- a/eodal/core/band.py
+++ b/eodal/core/band.py
@@ -1372,6 +1372,9 @@ class Band(object):
         meta["transform"] = self.transform
         meta["is_tile"] = self.is_tiled
         meta["driver"] = driver
+        # "compress" as suggested here:
+        # https://github.com/rasterio/rasterio/discussions/2933#discussioncomment-7208578
+        meta["compress"] = "DEFLATE"
         meta.update(kwargs)
 
         return meta
@@ -2371,6 +2374,9 @@ class Band(object):
         with rio.open(fpath_raster, "w+", **meta) as dst:
             # set band name
             dst.set_band_description(1, self.band_name)
+            # set scale and offset
+            dst._set_all_scales([self.scale])
+            dst._set_all_offsets([self.offset])
             # write band data
             if self.is_masked_array:
                 vals = self.values.data
@@ -2379,5 +2385,3 @@ class Band(object):
                 dst.write(self.values, 1)
             elif self.is_ndarray:
                 dst.write(self.values, 1)
-
-            # TODO: Write scale and offset to the file's metadata

--- a/eodal/core/band.py
+++ b/eodal/core/band.py
@@ -1691,7 +1691,6 @@ class Band(object):
             )
 
         # check if array is already masked
-        fill_value = None
         if self.is_masked_array:
             orig_mask = self.values.mask
             # update the existing mask
@@ -1700,8 +1699,13 @@ class Band(object):
                     # ignore pixels already masked
                     if not orig_mask[row, col]:
                         orig_mask[row, col] = mask[row, col]
+            # re-use original fill value
+            fill_value = self.values.fill_value
             # update band data array
-            masked_array = np.ma.MaskedArray(data=self.values.data, mask=orig_mask)
+            masked_array = np.ma.MaskedArray(
+                data=self.values.data,
+                mask=orig_mask,
+                fill_value=fill_value)
         elif self.is_ndarray:
             masked_array = np.ma.MaskedArray(data=self.values, mask=mask)
         elif self.is_zarr:

--- a/eodal/core/raster.py
+++ b/eodal/core/raster.py
@@ -1740,7 +1740,7 @@ class RasterCollection(MutableMapping):
         # open the result dataset and try to write the bands
         with rio.open(fpath_raster, "w+", **meta) as dst:
 
-            # set scale and offset
+            # set scales and offsets
             scales = [self[band_name].scale for band_name in band_selection]
             offsets = [self[band_name].offset for band_name in band_selection]
             dst._set_all_scales(scales)

--- a/eodal/core/raster.py
+++ b/eodal/core/raster.py
@@ -1743,8 +1743,8 @@ class RasterCollection(MutableMapping):
             # set scale and offset
             scales = [self[band_name].scale for band_name in band_selection]
             offsets = [self[band_name].offset for band_name in band_selection]
-            dst._set_all_scales([scales])
-            dst._set_all_offsets([offsets])
+            dst._set_all_scales(scales)
+            dst._set_all_offsets(offsets)
             
             for idx, band_name in enumerate(band_selection):
                 # check with band name to set

--- a/eodal/core/raster.py
+++ b/eodal/core/raster.py
@@ -1751,17 +1751,12 @@ class RasterCollection(MutableMapping):
                 dst.set_band_description(idx + 1, band_name)
                 # write band data. Cast to highest data type if necessary.
                 band_data = self.get_band(band_name).values.astype(highest_dtype)
-                # set masked pixels to nodata
-                if self[band_name].is_masked_array:
-                    vals = band_data.data
-                    mask = band_data.mask
-                    vals[mask] = self[band_name].nodata
                 dst.write(band_data, idx + 1)
 
     @check_band_names
     def to_xarray(self, band_selection: Optional[List[str]] = None) -> xr.DataArray:
         """
-        Converts bands in collection a ``xarray.DataArray``
+        Converts bands in collection into a ``xarray.DataArray``
 
         :param band_selection:
             selection of bands to process. If not provided uses all

--- a/eodal/core/sensors/sentinel2.py
+++ b/eodal/core/sensors/sentinel2.py
@@ -112,10 +112,11 @@ class Sentinel2(RasterCollection):
         baseline = get_S2_processing_baseline_from_safe(dot_safe_name=in_dir)
         # starting with baseline N0400 (400) S2 reflectances have an offset
         # value of -1000, i.e., the values reported in the .jp2 files must
-        # be subtracted by 1000 to obtain the actual reflectance factor values
+        # be subtracted by 1000 (0.1 in scaled representation) to obtain the
+        # actual reflectance factor values.
         s2_offset = 0
         if baseline >= 400:
-            s2_offset = 1000
+            s2_offset = 0.1
         return (s2_gain_factor, s2_offset)
 
     @staticmethod

--- a/eodal/core/sensors/sentinel2.py
+++ b/eodal/core/sensors/sentinel2.py
@@ -293,7 +293,7 @@ class Sentinel2(RasterCollection):
         masking_after_read_required = False
 
         if kwargs.get("vector_features") is not None:
-            bounds_df, shape_mask, lowest_resolution = adopt_vector_features_to_mask(
+            bounds_df, shape_mask, _ = adopt_vector_features_to_mask(
                 band_df=band_df_safe,
                 vector_features=kwargs.get("vector_features")
             )
@@ -382,9 +382,6 @@ class Sentinel2(RasterCollection):
                 )
             # apply actual vector features if masking is required
             if masking_after_read_required:
-                # nothing to do when the lowest resolution is passed
-                if band_safe.band_resolution.values == lowest_resolution:
-                    continue
                 # otherwise resample the mask of the lowest resolution to the
                 # current resolution using nearest neighbor interpolation
                 tmp = shape_mask.astype("uint8")

--- a/eodal/core/sensors/sentinel2.py
+++ b/eodal/core/sensors/sentinel2.py
@@ -394,7 +394,11 @@ class Sentinel2(RasterCollection):
                 )
                 # cast back to boolean
                 mask = res.astype("bool")
-                sentinel2.mask(mask=mask, bands_to_mask=[band_name], inplace=True)
+                sentinel2.mask(
+                    mask=mask,
+                    bands_to_mask=[band_name],
+                    inplace=True
+                )
         # scaling of reflectance values (i.e., do not scale SCL)
         if apply_scaling:
             sel_bands = sentinel2.band_names

--- a/eodal/core/sensors/sentinel2.py
+++ b/eodal/core/sensors/sentinel2.py
@@ -114,8 +114,8 @@ class Sentinel2(RasterCollection):
         # value of -1000, i.e., the values reported in the .jp2 files must
         # be subtracted by 1000 to obtain the actual reflectance factor values
         s2_offset = 0
-        if baseline == 400:
-            s2_offset = -1000
+        if baseline >= 400:
+            s2_offset = 1000
         return (s2_gain_factor, s2_offset)
 
     @staticmethod

--- a/eodal/core/sensors/sentinel2.py
+++ b/eodal/core/sensors/sentinel2.py
@@ -411,7 +411,8 @@ class Sentinel2(RasterCollection):
             )
         # set SCL fill value to 0
         if "SCL" in sentinel2.band_names:
-            sentinel2["SCL"].values.fill_value = 0
+            if sentinel2["SCL"].is_masked_array:
+                sentinel2["SCL"].values.fill_value = 0
         return sentinel2
 
     @classmethod

--- a/eodal/core/sensors/sentinel2.py
+++ b/eodal/core/sensors/sentinel2.py
@@ -409,6 +409,9 @@ class Sentinel2(RasterCollection):
                 band_selection=sel_bands,
                 pixel_values_to_ignore=[sentinel2[sentinel2.band_names[0]].nodata],
             )
+        # set SCL fill value to 0
+        if "SCL" in sentinel2.band_names:
+            sentinel2["SCL"].values.fill_value = 0
         return sentinel2
 
     @classmethod

--- a/eodal/core/utils/__init__.py
+++ b/eodal/core/utils/__init__.py
@@ -1,0 +1,38 @@
+
+import numpy as np
+
+
+# ranking of Python data types according to numpy
+DATATYPES = [
+    np.dtype('int'), np.dtype('int8'), np.dtype('int16'),
+    np.dtype('int32'),np.dtype('int64'), np.dtype('uint'),
+    np.dtype('uint8'), np.dtype('uint16'), np.dtype('uint32'),
+    np.dtype('uint64'), np.dtype('float16'), np.dtype('float32'),
+    np.dtype('float64'), np.dtype('float128'), np.dtype('complex64'),
+    np.dtype('complex128')
+]
+DTYPE_RANKS = {x: x.num for x in DATATYPES}
+
+
+def get_rank(dtype: np.dtype | str) -> int:
+    """
+    Get the rank of a data type
+
+    :param dtype: data type for which to get the rank.
+    :return: rank of `dtype` as defined by `numpy`.
+    """
+    if dtype in DTYPE_RANKS:
+        return DTYPE_RANKS[dtype]
+    else:
+        raise ValueError(f"Unknown data type: {dtype}")
+
+
+def get_highest_dtype(dtype_list: list[np.dtype | str]) -> np.dtype | str:
+    """
+    Get the highest data type of a list of data types based
+    on the data types ranks defined by `numpy`
+
+    :param dtype_list: list of data types
+    :return: higest data type in its `numpy.dtype` or string representation
+    """
+    return max(dtype_list, key=get_rank)

--- a/eodal/core/utils/__init__.py
+++ b/eodal/core/utils/__init__.py
@@ -8,7 +8,7 @@ DATATYPES = [
     np.dtype('int32'),np.dtype('int64'), np.dtype('uint'),
     np.dtype('uint8'), np.dtype('uint16'), np.dtype('uint32'),
     np.dtype('uint64'), np.dtype('float16'), np.dtype('float32'),
-    np.dtype('float64'), np.dtype('float128'), np.dtype('complex64'),
+    np.dtype('float64'), np.dtype('complex64'),
     np.dtype('complex128')
 ]
 DTYPE_RANKS = {x: x.num for x in DATATYPES}

--- a/eodal/mapper/mapper.py
+++ b/eodal/mapper/mapper.py
@@ -393,8 +393,9 @@ class Mapper:
 
         # make sure the time column is handled as pandas datetime
         # objects
-        scenes_df[self.time_column] = pd.to_datetime(
-            scenes_df[self.time_column], utc=True)
+        if not scenes_df.empty:
+            scenes_df[self.time_column] = pd.to_datetime(
+                scenes_df[self.time_column], utc=True)
 
         # populate the metadata attribute
         self.metadata = scenes_df

--- a/eodal/utils/geometry.py
+++ b/eodal/utils/geometry.py
@@ -96,6 +96,9 @@ def prepare_gdf(
     :returns:
         resulting GeoDataFrame sorted by sensing time.
     """
+    # return an empty GeoDataFrame if there are no entries
+    if len(metadata_list) == 0:
+        return gpd.GeoDataFrame()
     df = pd.DataFrame(metadata_list)
     df.sort_values(by="sensing_time", inplace=True)
     return gpd.GeoDataFrame(df, geometry="geom", crs=df.epsg.unique()[0])
@@ -111,8 +114,6 @@ def adopt_vector_features_to_mask(
     resolution. This is necessary to avoid artifacts (namely different
     spatial extents) in the data caused by the spatial subsetting with
     different pixel sizes.
-
-    ..versionadd:: 0.3.0
 
     :param band_df:
         DataFrame containing the band metadata.
@@ -155,7 +156,7 @@ def adopt_vector_features_to_mask(
             dataset=src,
             shapes=vector_features_geom,
             all_touched=True,
-            crop=True,
+            crop=True
         )
     # get upper left coordinates rasterio takes for the band
     # with the coarsest spatial resolution

--- a/examples/sentinel2_mapper.py
+++ b/examples/sentinel2_mapper.py
@@ -126,9 +126,9 @@ if __name__ == '__main__':
     # optional: get the least cloudy scene
     # to apply it uncomment the statement below. This
     # will return just a single scene no matter how long the time period chosen.
-    # mapper.metadata = mapper.metadata[
-    #       mapper.metadata.cloudy_pixel_percentage ==
-    #       mapper.metadata.cloudy_pixel_percentage.min()].copy()
+    mapper.metadata = mapper.metadata[
+          mapper.metadata.cloudy_pixel_percentage ==
+          mapper.metadata.cloudy_pixel_percentage.min()].copy()
 
     # we tell EOdal how to load the Sentinel-2 scenes using `Sentinel2.from_safe`
     # and pass on some kwargs, e.g., the selection of bands we want to read.
@@ -139,6 +139,7 @@ if __name__ == '__main__':
         'scene_constructor': Sentinel2.from_safe,
         'scene_constructor_kwargs': {'band_selection':
                                      ['B02', 'B03', 'B04', 'B08'],
+                                     'apply_scaling': False,
                                      'read_scl': True},
         'scene_modifier': preprocess_sentinel2_scenes,
         'scene_modifier_kwargs': {'target_resolution': 10}
@@ -147,7 +148,14 @@ if __name__ == '__main__':
     # load the scenes available from STAC
     mapper.load_scenes(scene_kwargs=scene_kwargs)
     # the data loaded into `mapper.data` as a EOdal SceneCollection
-    mapper.data
+    scoll = mapper.data
+
+    # save scenes as cloud-optimized GeoTiff
+    for timestamp, scene in scoll:
+        scene.to_rasterio(
+            f'data/{timestamp}.tiff',
+            band_selection=['red', 'green', 'blue', 'nir_1'],
+            as_cog=True)
 
     # plot scenes in collection
     f_scenes = mapper.data.plot(band_selection=['blue', 'green', 'red'])

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ setup(
     name='eodal',
     # setup_requires=['setuptools_scm'],
     # use_scm_version={'version_scheme': 'python-simplified-semver'},
-    version='0.2.2',
+    version='0.2.3',
     description='The Earth Observation Data Analysis Library EOdal',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,7 +264,8 @@ def get_scene_collection(get_bandstack):
         # open three scenes
         scene_list = []
         for i in range(3):
-            ds = RasterCollection.from_multi_band_raster(fpath_raster=fpath_raster)
+            ds = RasterCollection.from_multi_band_raster(
+                fpath_raster=fpath_raster, nodata=0)
             ds.scene_properties.acquisition_time = 1000 * (i+1)
             scene_list.append(ds)
         scoll = SceneCollection.from_raster_collections(

--- a/tests/core/test_band.py
+++ b/tests/core/test_band.py
@@ -249,6 +249,19 @@ def test_masking(datadir, get_test_band, get_bandstack, get_points3):
         'band data not the same after writing'
 
 
+def test_wrong_nodata_type(get_bandstack):
+    # usage of an incorrect no-data type (nan) for INT array
+    fpath_raster = get_bandstack()
+    with pytest.raises(TypeError):
+        band = Band.from_rasterio(
+            fpath_raster=fpath_raster,
+            band_idx=1,
+            band_name_dst='B02',
+            full_bounding_box_only=True,
+            nodata=np.nan
+        )
+
+
 def test_read_pixels(get_bandstack, get_test_band, get_polygons, get_points3):
     # read single pixels from raster dataset
     fpath_raster = get_bandstack()
@@ -285,7 +298,8 @@ def test_read_pixels(get_bandstack, get_test_band, get_polygons, get_points3):
         band_idx=1,
         band_name_dst='B02',
         vector_features=vector_features,
-        full_bounding_box_only=True
+        full_bounding_box_only=True,
+        nodata=0
     )
 
     assert not band.is_masked_array, 'data should not be masked'

--- a/tests/core/test_raster_algebra.py
+++ b/tests/core/test_raster_algebra.py
@@ -104,7 +104,7 @@ def test_raster_algebra_band_and_raster(get_bandstack):
     assert rcoll_le.get_values().any(), 'wrong results'
 
     # RasterCollection <-> RasterCollection
-    other = RasterCollection.from_multi_band_raster(fpath)
+    other = RasterCollection.from_multi_band_raster(fpath, nodata=0)
     rcoll_add = rcoll + other
     assert (rcoll_add.get_values() == rcoll.get_values() + other.get_values()).all(), 'wrong result'
     rcoll_sub = rcoll - other

--- a/tests/core/test_raster_algebra.py
+++ b/tests/core/test_raster_algebra.py
@@ -7,7 +7,7 @@ from eodal.core.raster import RasterCollection
 def test_raster_algebra_scalar(get_bandstack):
     """test algebraic operations using scalar values on RasterCollections"""
     fpath = get_bandstack()
-    rcoll = RasterCollection.from_multi_band_raster(fpath)
+    rcoll = RasterCollection.from_multi_band_raster(fpath, nodata=0)
     scalar = 2
 
     # arithmetic operators
@@ -78,7 +78,7 @@ def test_raster_algebra_scalar(get_bandstack):
 def test_raster_algebra_band_and_raster(get_bandstack):
     """test algebraic operations using Bands and Rasters on RasterCollections"""
     fpath = get_bandstack()
-    rcoll = RasterCollection.from_multi_band_raster(fpath)
+    rcoll = RasterCollection.from_multi_band_raster(fpath, nodata=0)
     band = rcoll['B02'].copy()
 
     # RasterCollection <-> Band

--- a/tests/core/test_raster_apply.py
+++ b/tests/core/test_raster_apply.py
@@ -57,7 +57,7 @@ def test_apply_custom_function(get_bandstack):
     """
     fpath_raster = get_bandstack()
     gTiff_collection = RasterCollection.from_multi_band_raster(
-        fpath_raster=fpath_raster
+        fpath_raster=fpath_raster, nodata=0
     )
 
     # define a custom function for calculation the square root of values

--- a/tests/core/test_raster_copy.py
+++ b/tests/core/test_raster_copy.py
@@ -13,7 +13,8 @@ def test_raster_copy(get_bandstack):
     fpath_raster = get_bandstack()
     rcoll = RasterCollection.from_multi_band_raster(
         fpath_raster=fpath_raster,
-        band_aliases=['a','b','c','d','e','f','g','h','i','j']
+        band_aliases=['a','b','c','d','e','f','g','h','i','j'],
+        nodata=0
     )
     rcoll_copy = rcoll.copy()
 

--- a/tests/core/test_raster_iterator.py
+++ b/tests/core/test_raster_iterator.py
@@ -15,7 +15,7 @@ def test_raster_iterator(get_bandstack):
 
     fpath_raster = get_bandstack()
     ds = RasterCollection.from_multi_band_raster(
-        fpath_raster=fpath_raster
+        fpath_raster=fpath_raster, nodata=0
     )
     band_names = ds.band_names
 

--- a/tests/core/test_raster_slicing.py
+++ b/tests/core/test_raster_slicing.py
@@ -16,7 +16,8 @@ def test_raster_slice(get_bandstack):
                    'nir1', 'nir2', 'swir1', 'swir2']
     ds = RasterCollection.from_multi_band_raster(
         fpath_raster=fpath_raster,
-        band_aliases=color_names
+        band_aliases=color_names,
+        nodata=0
     )
 
     # slicing using band names

--- a/tests/core/test_scene_collection.py
+++ b/tests/core/test_scene_collection.py
@@ -51,7 +51,7 @@ def test_raster_is_scene(get_bandstack):
 
     fpath_raster = get_bandstack()
     ds = RasterCollection.from_multi_band_raster(
-        fpath_raster=fpath_raster
+        fpath_raster=fpath_raster, nodata=0
     )
     assert not ds.is_scene, 'scene metadata have not been set, so it is not a scene'
 
@@ -105,7 +105,8 @@ def test_scene_collection(get_s2_safe_l2a, get_polygons_2, get_bandstack):
     with pytest.raises(ValueError):
         scoll = SceneCollection(
             scene_constructor=RasterCollection.from_multi_band_raster,
-            fpath_raster=fpath_no_scene
+            fpath_raster=fpath_no_scene,
+            nodata=0
         )
 
     # add another scene


### PR DESCRIPTION
This PR addresses #77 that shed some light on masking issues in EOdal. In particular, the mask of the Sentinel-2 Scene Classification layer was not propagated correctly. While debugging this issue, I found some general problems with the propagation of data types, fill and nodata values caused by inconsistencies in the code and poor type checking.

The major fixes include:
- a fill value is now explicitly set to each `np.ma.masked_array`. If not (previous behavior) numpy would interfere a fill value that would often not be the no-data type of the raster. In the forthcoming release of EOdal, the fill-value will now equal the nodata value.
- the inference of the highest data type in a `RasterCollection` has been improved and extended to all `INT`,  `FLOAT`, and `COMPLEX` data types currently supported by numpy. In the previous version, all data types were cast to `numpy.float32` or even `numpy.float64` leading to an unnecessary high consumption of memory.
- the `scale` and `offset` parameters are now correctly written to the file metadata when exporting a `Band` or `RasterCollection` object. In previous versions of EOdal, the information about this two attributes was not written to output. Also, the way scale and offset are applied, is now consistent with `QGIS` meaning that raster files created by EOdal will be shown with correct scale and offset in QGIS (QGIS applies them on the fly when displaying the raster data)

In addition, a new feature was implemented allowing to create `cloud-optimized GeoTiffs (COG)` from `RasterCollection` objects. A new keyword-argument `as_cog` has been added to `RasterCollection.to_rasterio`. `as_cog` is False by default. If True, a COG will be generated.