### PR TITLE
Fixed broken creodias download (#79)

### DIFF
--- a/eodal/config/settings.py
+++ b/eodal/config/settings.py
@@ -52,6 +52,11 @@ class Settings(BaseSettings):
     # define CREODIAS username and password
     CREODIAS_USER: str = ""
     CREODIAS_PASSWORD: str = ""
+    # define CREODIAS TOTP secret for 2FA
+    CREODIAS_TOTP_SECRET: str = ""
+    # CREODIAS API endpoint for downloading zipped datasets
+    CREODIAS_ZIPPER_URL: str = "https://zipper.creodias.eu/download"
+
     # maximum number of records per request: 2000 (CREODIAS currently does not allow
     # more)
     CREODIAS_MAX_RECORDS: int = 2000

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ alive_progress
 rasterstats
 pyyaml
 myst_parser
+pyotp


### PR DESCRIPTION
This PR fixes #79, i.e., the broken CREODIAS download of full Sentinel scenes.

In more detail:
- the API endpoints were updated
- 2FA now enforced by CREODIAS has been implemented using `pyotp` to sign requests to get a keycloak token required to download datasets
- the download functionality has been made more robust by adding try-excepts blocks and enhanced logging of errors.