### PR TITLE
FIX: Sentinel-2 extraction failing due to change of EPSG keyword in some scene properties

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        python -m pip install --upgrade pip
         python -m pip install --upgrade pip wheel
         python -m pip install --editable .[test]
 

--- a/eodal/core/band.py
+++ b/eodal/core/band.py
@@ -586,7 +586,7 @@ class Band(object):
     @property
     def is_zarr(self) -> bool:
         """Checks if the band values are a zarr array"""
-        return isinstance(self.values, zarr.core.Array)
+        return isinstance(self.values, zarr.core.array.Array)
 
     @property
     def is_ndarray(self) -> bool:

--- a/eodal/metadata/stac/client.py
+++ b/eodal/metadata/stac/client.py
@@ -192,6 +192,13 @@ def sentinel2(metadata_filters: List[Filter], **kwargs) -> gpd.GeoDataFrame:
             scene_id = props[s2.scene_id]
         except KeyError:
             scene_id = scene[s2.scene_id]
+
+        # there are two different keys for the EPSG code
+        try:
+            epsg = props[s2.epsg]
+        except KeyError:
+            epsg = props['proj:code']
+
         # TODO: think about a more generic way to do this. The problem is:
         # we need to map the different STAC provider settings into EOdals
         # metadata model to avoid having the user to think about it
@@ -202,7 +209,7 @@ def sentinel2(metadata_filters: List[Filter], **kwargs) -> gpd.GeoDataFrame:
             "tile_id": tile_id,
             "sensing_date": datetime_to_date(props[s2.sensing_time]),
             "cloudy_pixel_percentage": props[s2.cloud_cover],
-            "epsg": props[s2.epsg],
+            "epsg": epsg,
             "sensing_time": datetime.strptime(
                 props[s2.sensing_time], s2.sensing_time_fmt
             ),

--- a/eodal/metadata/stac/client.py
+++ b/eodal/metadata/stac/client.py
@@ -199,7 +199,10 @@ def sentinel2(metadata_filters: List[Filter], **kwargs) -> gpd.GeoDataFrame:
         except KeyError:
             epsg = props['proj:code']
             # eliminate the 'EPSG:' part of the string
-            epsg = epsg.split(":")[-1]
+            try:
+                epsg = int(epsg.split(":")[-1])
+            except ValueError:
+                raise ValueError(f"Could not extract EPSG code from {epsg}")
 
         # TODO: think about a more generic way to do this. The problem is:
         # we need to map the different STAC provider settings into EOdals

--- a/eodal/metadata/stac/client.py
+++ b/eodal/metadata/stac/client.py
@@ -198,6 +198,8 @@ def sentinel2(metadata_filters: List[Filter], **kwargs) -> gpd.GeoDataFrame:
             epsg = props[s2.epsg]
         except KeyError:
             epsg = props['proj:code']
+            # eliminate the 'EPSG:' part of the string
+            epsg = epsg.split(":")[-1]
 
         # TODO: think about a more generic way to do this. The problem is:
         # we need to map the different STAC provider settings into EOdals


### PR DESCRIPTION
Hi @helgeaasen,

We recently found a small problem with some - seemingly reprocessed - Sentinel-2 scenes. In these scenes, the keyword for the EPSG code was changed from `proj:epsg` to `proj:code`. I added a try-except block in `metadata.stac.client.py` to avoid requests failing due to the changed key.

Thanks for merging this PR!